### PR TITLE
Fix wrong class name on PnmlExport.exportObject

### DIFF
--- a/pnmlFw-Utils/src/fr/lip6/move/pnml/framework/general/PnmlExport.java
+++ b/pnmlFw-Utils/src/fr/lip6/move/pnml/framework/general/PnmlExport.java
@@ -185,7 +185,7 @@ public class PnmlExport extends AbstractPnmlImportExport {
 
 		out = new File(filepath);
 
-		final String classname = object.getClass().getCanonicalName();
+		final String classname = object.eClass().getInstanceClassName();
 
 		PNMLFileType otype = OfficialPNMLFileType
 				.getByNativeClassName(classname);


### PR DESCRIPTION
Patch for `fr.lip6.move.pnml.framework.general.PnmlExport` to fix issue https://github.com/lhillah/pnmlframework/issues/1
