### PR TITLE
Fix resource (FileInputStream) leakage

### DIFF
--- a/pnmlFw-Utils/src/fr/lip6/move/pnml/framework/general/PnmlImport.java
+++ b/pnmlFw-Utils/src/fr/lip6/move/pnml/framework/general/PnmlImport.java
@@ -383,15 +383,18 @@ public class PnmlImport extends AbstractPnmlImportExport { // NOPMD by ggiffo
                 .getDocumentElement();*/
         
         OMElement document = null;
-        try { 
+        try (
         	InputStream in = new BufferedInputStream(new FileInputStream(path));
+        	) {
         	//create the builder
         	OMXMLParserWrapper builder = OMXMLBuilderFactory.createOMBuilder(in);
         	//get the root element
         	document = builder.getDocumentElement();
         } catch (FileNotFoundException e) {
            throw e;
-        }
+        } catch (IOException e) {
+        	throw new OtherException(e);
+		}
         return document;
     }
 


### PR DESCRIPTION
There's a resource leakage in the `PnmlImport.getDocument(String path)` function (`FileInputStream` is not closed). This makes that files can remain locked after their use in systems like windows (that locks files on use), preventing them from being deleted in the eclipse workspace.

The diff on this pull request git detects all the file has changed becuase of different spacing. To make it clear, the changed code is:

* Original:
```
try {
	InputStream in = new BufferedInputStream(new FileInputStream(path));
	// create the builder
	OMXMLParserWrapper builder = OMXMLBuilderFactory.createOMBuilder(in);
	// get the root element
	document = builder.getDocumentElement();
} catch (FileNotFoundException e) {
	throw e;
}
```

* Replacement:
```
try (InputStream in = new BufferedInputStream(new FileInputStream(path));) {
	// create the builder
	OMXMLParserWrapper builder = OMXMLBuilderFactory.createOMBuilder(in);
	// get the root element
	document = builder.getDocumentElement();
} catch (FileNotFoundException e) {
	throw e;
} catch (IOException e) {
	throw new OtherException(e);
}
```