### PR TITLE
force to build document before closing the stream.

### DIFF
--- a/pnmlFw-Utils/src/fr/lip6/move/pnml/framework/general/PnmlImport.java
+++ b/pnmlFw-Utils/src/fr/lip6/move/pnml/framework/general/PnmlImport.java
@@ -390,6 +390,7 @@ public class PnmlImport extends AbstractPnmlImportExport { // NOPMD by ggiffo
         	OMXMLParserWrapper builder = OMXMLBuilderFactory.createOMBuilder(in);
         	//get the root element
         	document = builder.getDocumentElement();
+        	document.build();
         } catch (FileNotFoundException e) {
            throw e;
         } catch (IOException e) {


### PR DESCRIPTION
As specified by Apache documentation, 
"Because Axiom uses deferred parsing, the stream must be closed AFTER processing the document (unless OMElement#build() is called)"

the parse may be incomplete when the current code closes the input stream, leading to downstream exceptions when later using a large file (Colored in particular). This patch forces to finish the parse before exiting the function.

So this patches the patch of Abel, but loses some on the-fly-ness from the parser.